### PR TITLE
Add GitHub Pages link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ elm-test
 
 ## Deployment
 The app is automatically built and deployed to GitHub Pages via GitHub Actions on every push to the `master` branch.
+
+https://asssaf.github.io/datasf-web/


### PR DESCRIPTION
Added the GitHub Pages URL `https://asssaf.github.io/datasf-web/` to the "Deployment" section of `README.md` as requested.
Verified that the link is correctly placed and that existing tests still pass.
Removed temporary npm files created during testing to keep the codebase clean.

---
*PR created automatically by Jules for task [1666875572485858343](https://jules.google.com/task/1666875572485858343) started by @asssaf*