### PR TITLE
Improve table header formatting and wrapping

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -322,11 +322,26 @@ viewTable model results =
     div [ class "table-responsive" ]
         [ table [ class "table table-striped table-hover table-sm" ]
             [ thead []
-                [ tr [] (List.map (\h -> th [] [ text h ]) headers) ]
+                [ tr [] (List.map (\h -> th [ style "max-width" "100px", style "white-space" "normal" ] [ text (formatHeader h) ]) headers) ]
             , tbody []
                 (List.map (viewRow headers) results)
             ]
         ]
+
+formatHeader : String -> String
+formatHeader field =
+    if field == "the_geom" then
+        "Coordinates"
+
+    else
+        field
+            |> String.split "_"
+            |> List.map capitalize
+            |> String.join " "
+
+capitalize : String -> String
+capitalize word =
+    (String.left 1 word |> String.toUpper) ++ String.dropLeft 1 word
 
 viewRow : List String -> Property -> Html Msg
 viewRow headers prop =


### PR DESCRIPTION
This change improves the user interface of the property data search tool by making table headers more human-friendly. It converts technical snake_case field names to Title Case, renames the geometry field to "Coordinates", and ensures headers wrap within a reasonable width (100px) to maintain a compact table layout. All changes were verified with automated tests and visual inspection.

---
*PR created automatically by Jules for task [8923934067854951333](https://jules.google.com/task/8923934067854951333) started by @asssaf*